### PR TITLE
Pull in model module from pircel

### DIFF
--- a/possel/application.py
+++ b/possel/application.py
@@ -8,7 +8,7 @@ import socket
 import ssl
 
 from OpenSSL import crypto
-from pircel import model, tornado_adapter
+from pircel import tornado_adapter
 
 from playhouse import db_url
 
@@ -16,7 +16,7 @@ import tornado.ioloop
 import tornado.web
 from tornado.web import url
 
-from possel import auth, push, resources, web_client
+from possel import auth, model, push, resources, web_client
 
 
 def get_routes(interfaces):

--- a/possel/auth.py
+++ b/possel/auth.py
@@ -11,9 +11,9 @@ from cryptography.hazmat import backends
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf import pbkdf2
 import peewee as p
-from pircel import model
 import tornado.web
 
+from possel import model
 
 logger = logging.getLogger(__name__)
 

--- a/possel/commands.py
+++ b/possel/commands.py
@@ -4,7 +4,9 @@ import argparse
 import collections
 import logging
 
-from pircel import model, tornado_adapter
+from pircel import tornado_adapter
+
+from possel import model
 
 logger = logging.getLogger(__name__)
 

--- a/possel/model.py
+++ b/possel/model.py
@@ -217,7 +217,7 @@ class IRCServerController:
             IRCBufferModel.get_or_create(name=channel, server=self._server_model)
         else:  # Someone is joining a channel we're already in
             buffer = IRCBufferModel.get(name=channel, server=self._server_model)
-            user, created = IRCUserModel.get_or_create(nick=nick,
+            user, created = IRCUserModel.create_or_get(nick=nick,
                                                        username=username,
                                                        host=host,
                                                        server=self._server_model)
@@ -258,7 +258,7 @@ class IRCServerController:
         if nick[0] in '@+':
             nick = nick[1:]
 
-        user, created = IRCUserModel.get_or_create(nick=nick, server=self._server_model)
+        user, created = IRCUserModel.create_or_get(nick=nick, server=self._server_model)
         return user
 
     @property

--- a/possel/model.py
+++ b/possel/model.py
@@ -110,6 +110,8 @@ class IRCUserModel(UserDetails):
     """ Models users that are connected to an IRC Server.
 
     Inherits most of its fields from UserDetails.
+
+    Don't delete user models, they're needed for line models.
     """
     host = p.TextField(null=True)  # where they're coming from
     server = p.ForeignKeyField(IRCServerModel, related_name='users', on_delete='CASCADE')
@@ -143,11 +145,11 @@ class IRCLineModel(BaseModel):
     Typically this will be messages, notices, CTCP ACTIONs, joins, quits, mode changes, topic changes, etc.
     """
     # Where
-    buffer = p.ForeignKeyField(IRCBufferModel, related_name='lines')
+    buffer = p.ForeignKeyField(IRCBufferModel, related_name='lines', on_delete='CASCADE')
 
     # Who and when
     timestamp = p.DateTimeField(default=datetime.datetime.now)
-    user = p.ForeignKeyField(IRCUserModel, null=True)  # Can have lines with no User displayed
+    user = p.ForeignKeyField(IRCUserModel, null=True, on_delete='CASCADE')  # Can have lines with no User displayed
 
     # What
     kind = p.CharField(max_length=20, default='message', choices=line_types)

--- a/possel/model.py
+++ b/possel/model.py
@@ -47,7 +47,7 @@ class KeyDefaultDict(collections.defaultdict):
             return super(KeyDefaultDict, self).__missing__(key)
 
 
-database = p.Database(None)  # Passing None means we can initialise it later with database.init('sqlite...')
+database = p.Proxy()
 
 
 class BaseModel(p.Model):
@@ -150,6 +150,16 @@ class IRCBufferMembershipRelation(BaseModel):
     """ Buffers and Users have a many-to-many relationship, this handles that. """
     buffer = p.ForeignKeyField(IRCBufferModel, related_name='memberships', on_delete='CASCADE')
     user = p.ForeignKeyField(IRCUserModel, related_name='memberships', on_delete='CASCADE')
+
+
+def create_tables():
+    database.create_tables([UserDetails,
+                            IRCServerModel,
+                            IRCUserModel,
+                            IRCBufferModel,
+                            IRCLineModel,
+                            IRCBufferMembershipRelation,
+                            ], safe=True)
 
 
 class IRCServerController:

--- a/possel/model.py
+++ b/possel/model.py
@@ -12,6 +12,7 @@ import functools
 import logging
 
 import peewee as p
+from playhouse import shortcuts
 
 import pircel
 from pircel import protocol
@@ -57,6 +58,9 @@ database = p.Proxy()
 class BaseModel(p.Model):
     class Meta:
         database = database
+
+    def to_dict(self):
+        return shortcuts.model_to_dict(self, recurse=False)
 
 
 class UserDetails(BaseModel):
@@ -148,6 +152,11 @@ class IRCLineModel(BaseModel):
     # What
     kind = p.CharField(max_length=20, default='message', choices=line_types)
     content = p.TextField()
+
+    def to_dict(self):
+        d = shortcuts.model_to_dict(self, recurse=False)
+        d['timestamp'] = d['timestamp'].replace(tzinfo=datetime.timezone.utc).timestamp()
+        return d
 
 
 class IRCBufferMembershipRelation(BaseModel):

--- a/possel/model.py
+++ b/possel/model.py
@@ -138,7 +138,8 @@ line_types = [('message', 'Message'),
               ('notice', 'Notice'),
               ('join', 'Join'),
               ('part', 'Part'),
-              ('quit', 'quit'),
+              ('quit', 'Quit'),
+              ('action', 'Action'),
               ('other', 'Other'),
               ]  # TODO: Consider more/less line types? Line types as display definitions?
 
@@ -339,7 +340,13 @@ class IRCServerInterface:
             buffer = ensure_buffer(name=to, server=self.server_model)
 
         user = ensure_user(nick=nick, server=self.server_model)
-        create_line(buffer=buffer, user=user, kind='message', content=msg)
+        action_prefix = '\1ACTION '
+        kind = 'message'
+        if msg.startswith(action_prefix):
+            msg = msg[len(action_prefix):-1]
+            kind = 'action'
+
+        create_line(buffer=buffer, user=user, kind=kind, content=msg)
 
     def _handle_rpl_namreply(self, _, **kwargs):
         to, channel_privacy, channel, space_sep_names = kwargs['args']

--- a/possel/model.py
+++ b/possel/model.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+pircel.model
+------------
+
+This module defines an API for storing the state of an IRC server and probably includes some database bits too.
+"""
+import collections
+import functools
+import logging
+
+import peewee as p
+
+import pircel
+from pircel import protocol
+
+logger = logging.getLogger(__name__)
+
+
+class Error(pircel.Error):
+    """ Root exception for model related exceptions.
+
+    e.g. Exceptions which are thrown when there is a state mismatch. """
+
+
+class UserNotFoundError(Error):
+    """ Exception Thrown when action is performed on non-existent nick.  """
+
+
+class UserAlreadyExistsError(Error):
+    """ Exception Thrown when there is an attempt at overwriting an existing user. """
+
+
+class ModeNotFoundError(Error):
+    """ Exception thrown when we try to remove a mode that a user doesn't have. """
+
+
+class KeyDefaultDict(collections.defaultdict):
+    """ defaultdict modification that provides the key to the factory. """
+    def __missing__(self, key):
+        if self.default_factory is not None:
+            self[key] = self.default_factory(key)
+            return self[key]
+        else:
+            return super(KeyDefaultDict, self).__missing__(key)
+
+
+class IRCServerModel(p.Model):
+    pass
+
+
+class IRCServerController(object):
+    def __init__(self, server_model):
+        pass
+
+    def get_user_full(self, who):
+        """ Return the User object for a given IRC identity string, creating if necessary.
+
+        Args:
+            who (str): Full IRC identity string (as specified in §2.3.1 of rfc2812, second part of "prefix" definition)
+                       of the user
+        Returns:
+            A User object with a nick property that is unique between this method and `get_user_by_nick`; e.g.
+            subsequent calls of either with the same *nick* part will result in the same object being returned.
+        """
+        nick, username, host = protocol.parse_identity(who)
+        try:
+            user = self.users[nick]
+            if not user.fully_known:
+                user.username = username
+                user.fully_known = True
+            return user
+        except KeyError:
+            self.users[nick] = User(nick, username)
+            self.users[nick].fully_known = True
+            return self.users[nick]
+
+    def get_user_by_nick(self, nick, channel=None):
+        """ Return the user object from just the nick.
+
+        Will also parse "@nick" or "+nick" properly, and set the mode if the channel is provided.
+
+        Args:
+            nick (str): Either the nick or the nick with a channel mode prefix.
+            channel (str): The name of the channel if this is being called from a 'RPL_NAMREPLY' callback.
+        Returns:
+            A User object for the specified nick; this object will be unique by nick if only this method and
+            `get_user_full` are used to get User objects.
+        """
+        # Pull @ or + off the front
+        # I checked the RFC; these should be the only two chars
+        mode = None
+        if nick[0] in '@+':
+            mode = nick[0]
+            nick = nick[1:]
+
+        # Get or create and get the user object
+        try:
+            user = self.users[nick]
+        except KeyError:
+            self.users[nick] = User(nick)
+            user = self.users[nick]
+
+        # Set +o or +v if we need to
+        if channel is not None and mode is not None:
+            mode = {'@': 'o', '+': 'v'}[mode]  # Look it up in a local dict
+            user.modes[channel].add(mode)
+
+        return user
+
+    # ==========
+    # JOIN stuff
+    def on_join(self, who, channel):
+        user = self.get_user_full(who)
+        if user is self.identity:
+            self.self_join(channel)
+        else:
+            self.channels[channel].user_join(user)
+
+    def self_join(self, channel):
+        pass
+
+    def on_rpl_namreply(self, prefix, recipient, secrecy, channel, nicks):
+        """ Sent when you join a channel or run /names """
+        for nick in nicks.split():
+            user = self.get_user_by_nick(nick, channel)
+            self.channels[channel].user_join(user)
+
+    def on_rpl_endofnames(self, *args):
+        """ Sent when we're done with rpl_namreply messages """
+        pass
+    # ==========
+
+    def on_notice(self, prefix, _, message):
+        logger.info('NOTICE: %s', message)
+
+    def on_mode(self, prefix, channel, command, nick):
+        user = self.get_user_by_nick(nick)
+        user.apply_mode_command(channel, command)
+
+    def on_nick(self, who, new_nick):
+        user = self.get_user_full(who)
+        logger.debug('User %s changed nick to %s', user.nick, new_nick)
+        del self.users[user.nick]
+        user.name = new_nick
+        self.users[new_nick] = user
+
+    def on_quit(self, who, message):
+        user = self.get_user_full(who)
+        if user != self.identity:
+            for channel in self.channels:
+                try:
+                    self.channels[channel].user_part(user)
+                except UserNotFoundError:
+                    pass
+
+    def on_part(self, who, channel):
+        user = self.get_user_full(who)
+        if user != self.identity:
+            self.channels[channel].user_part(user)
+
+    def on_privmsg(self, who_from, to, msg):
+        if to.startswith('#'):
+            user = self.get_user_full(who_from)
+            self.channels[to].on_new_message(user, msg)
+
+    def on_rpl_isupport(self, *args):
+        logger.debug('Server supports: %s', args)
+
+    def on_rpl_motdstart(self, *args):
+        self.motd = ''
+
+    def on_rpl_motd(self, prefix, recipient, motd_line):
+        self.motd += motd_line
+        self.motd += '\n'
+
+    def on_rpl_endofmotd(self, *args):
+        logger.info(self.motd)
+        self.who('0')
+
+    def on_rpl_whoreply(self, prefix, recipient, channel, user, host, server, nick, *args):
+        # the last parameter will always be there, there are a bunch of optionals in between
+        *args, hopcount_and_realname = args
+
+        hopcount, realname = hopcount_and_realname.split(' ', maxsplit=1)
+        user = self.get_user_full('{}!{}@{}'.format(nick, user, host))
+        user.real_name = realname
+    # =============
+    # Handlers done
+    # =============
+
+
+@functools.total_ordering
+class User:
+    def __init__(self, name, username=None, real_name=None, password=None):
+        self.name = name
+        self.username = username or name
+        self.real_name = real_name or name
+        self.modes = collections.defaultdict(set)
+        self.fully_known = False
+
+    @property
+    def nick(self):
+        return self.name
+
+    def apply_mode_command(self, channel, command):
+        """ Applies a mode change command.
+
+        Similar syntax to the `chmod` program.
+        """
+        direction, mode = command
+        if direction == '+':
+            self.modes[channel].add(mode)
+        elif direction == '-' and mode in self.modes:
+            self.modes[channel].remove(mode)
+        elif mode not in self.modes:
+            raise ModeNotFoundError(
+                'User "{}" doesn\'t have mode "{}" that we were told to remove'.format(self.name, mode))
+        else:
+            raise protocol.UnknownModeCommandError('Unknown mode change command'
+                                                   ' "{}", expecting "-" or "+"'.format(command))
+
+    def __str__(self):
+        modes = set()
+        for m in self.modes.values():
+            modes |= m
+
+        if self.fully_known:
+            modes.add('&')
+
+        return '{}!{} +{}'.format(self.name, self.username,
+                                  ''.join(modes))
+
+    def __repr__(self):
+        return str(self)
+
+    def __eq__(self, other):
+        return self.name == other.name
+
+    def __lt__(self, other):
+        return self.name < other.name
+
+    def __gt__(self, other):
+        return self.name > other.name
+
+    def __hash__(self):
+        return hash(self.name)
+
+
+class IRCChannel:
+    def __init__(self, name, server, debug_out_loud=False):
+        self.server = server
+        self._write = server.write_function
+        self.name = name
+        self.identity = server.identity
+        self.users = set()
+        self.messages = []
+
+        self._debug_out_loud = debug_out_loud
+
+    def user_join(self, user):
+        logger.debug('%s joined %s', user, self.name)
+        if user.nick in self.users:
+            raise UserAlreadyExistsError(
+                'Tried to add user "{}" to channel {}'.format(user.nick, self.name)
+            )
+        self.users.add(user)
+
+    def user_part(self, user):
+        logger.debug('%s parted from %s', user, self.name)
+        try:
+            self.users.remove(user)
+        except KeyError as e:
+            raise UserNotFoundError(
+                'Tried to remove non-existent nick "{}" from channel {}'.format(user.nick, self.name)) from e
+
+    def on_new_message(self, who_from, msg):
+        self.messages.append((who_from, msg))
+
+        if msg.startswith('!d listmessages'):
+            logger.debug(self.messages)
+
+            if self._debug_out_loud:
+                self.send_message(self.messages)
+
+        elif msg.startswith('!d listusers'):
+            logger.debug(self.server.users)
+
+            if self._debug_out_loud:
+                for user in sorted(self.server.users.values()):
+                    self.send_message(user)
+
+        elif msg.startswith('!d raise'):
+            raise Error('Debug exception')
+
+    def join(self, password=None):
+        logger.debug('Joining %s', self.name)
+        if password:
+            self._write('JOIN {} {}'.format(self.name, password))
+        else:
+            self._write('JOIN {}'.format(self.name))
+
+    def part(self):
+        pass
+
+    def send_message(self, message):
+        if not isinstance(message, (str, bytes)):
+            message = str(message)
+        for line in message.split('\n'):
+            self.messages.append((self.identity, line))
+            self._write('PRIVMSG {} :{}'.format(self.name, line))
+
+
+def main():
+    pass
+
+if __name__ == '__main__':
+    main()

--- a/possel/model.py
+++ b/possel/model.py
@@ -296,7 +296,7 @@ def create_membership(buffer, user):
 def delete_membership(user, buffer):
     membership = IRCBufferMembershipRelation.get(user=user, buffer=buffer)
     membership.delete_instance()
-    signal_factory(deleted_membership).send(None, membership=membership)
+    signal_factory(deleted_membership).send(None, membership=membership, buffer=buffer, user=user)
 
 
 def create_server(host, port, secure, nick, realname, username):

--- a/possel/model.py
+++ b/possel/model.py
@@ -260,6 +260,23 @@ class IRCServerController:
 
         user, created = IRCUserModel.get_or_create(nick=nick, server=self._server_model)
         return user
+
+    @property
+    def connection_details(self):
+        m = self._server_model
+        return m.host, m.port, m.secure
+
+    @property
+    def identity(self):
+        return self._user
+
+    @property
+    def channels(self):
+        n = IRCBufferModel.name
+        return self._server_model.buffers.where(n.startswith('#') |
+                                                n.startswith('&') |
+                                                n.startswith('+') |
+                                                n.startswith('!'))
     # =========================================================================
 
     # =========================================================================
@@ -278,7 +295,7 @@ class IRCServerController:
     @classmethod
     def get_all(cls):
         models = IRCServerModel.select()
-        return [cls(model) for model in models]
+        return {model.id: cls(model) for model in models}
     # =========================================================================
 
 

--- a/possel/model.py
+++ b/possel/model.py
@@ -134,7 +134,7 @@ class IRCBufferModel(BaseModel):
     This means channels and PMs.
     """
     name = p.TextField()  # either a channel '#channel' or a nick 'nick'
-    server = p.ForeignKeyField(IRCServerModel, related_name='buffers', on_delete='CASCADE')
+    server = p.ForeignKeyField(IRCServerModel, related_name='buffers', on_delete='CASCADE', null=True)
     kind = p.CharField(max_length=20, default='normal', choices=buffer_types)
 
     class Meta:
@@ -186,7 +186,7 @@ class IRCBufferMembershipRelation(BaseModel):
                    )
 
 
-def create_tables():
+def initialize():
     database.create_tables([UserDetails,
                             IRCServerModel,
                             IRCUserModel,
@@ -194,6 +194,12 @@ def create_tables():
                             IRCLineModel,
                             IRCBufferMembershipRelation,
                             ], safe=True)
+    try:
+        logger.info('Getting')
+        IRCBufferModel.get(name='System Buffer', kind='system')
+    except p.DoesNotExist:
+        logger.info('Creating')
+        IRCBufferModel.create(name='System Buffer', server=None, kind='system')
 
 
 # Callback signal definitions

--- a/possel/model.py
+++ b/possel/model.py
@@ -162,7 +162,7 @@ class IRCLineModel(BaseModel):
     buffer = p.ForeignKeyField(IRCBufferModel, related_name='lines', on_delete='CASCADE')
 
     # Who and when
-    timestamp = p.DateTimeField(default=datetime.datetime.now)
+    timestamp = p.DateTimeField(default=datetime.datetime.utcnow)
     user = p.ForeignKeyField(IRCUserModel, null=True, on_delete='CASCADE')  # Can have lines with no User displayed
     nick = p.TextField(null=True)  # We store the nick of the user at the time of the message
 

--- a/possel/model.py
+++ b/possel/model.py
@@ -168,7 +168,7 @@ class _OLD_DEPRECATED_IRCServerController:  # noqa
                 user.fully_known = True
             return user
         except KeyError:
-            self.users[nick] = User(nick, username)
+            self.users[nick] = User(nick, username)  # noqa
             self.users[nick].fully_known = True
             return self.users[nick]
 
@@ -195,7 +195,7 @@ class _OLD_DEPRECATED_IRCServerController:  # noqa
         try:
             user = self.users[nick]
         except KeyError:
-            self.users[nick] = User(nick)
+            self.users[nick] = User(nick)  # noqa
             user = self.users[nick]
 
         # Set +o or +v if we need to
@@ -288,7 +288,7 @@ class _OLD_DEPRECATED_IRCServerController:  # noqa
 
 
 @functools.total_ordering
-class User:
+class _OLD_DEPRECATED_User:  # noqa
     def __init__(self, name, username=None, real_name=None, password=None):
         self.name = name
         self.username = username or name

--- a/possel/model.py
+++ b/possel/model.py
@@ -155,6 +155,7 @@ class IRCLineModel(BaseModel):
     # Who and when
     timestamp = p.DateTimeField(default=datetime.datetime.now)
     user = p.ForeignKeyField(IRCUserModel, null=True, on_delete='CASCADE')  # Can have lines with no User displayed
+    nick = p.TextField(null=True)  # We store the nick of the user at the time of the message
 
     # What
     kind = p.CharField(max_length=20, default='message', choices=line_types)
@@ -227,7 +228,10 @@ def update_user(old_nick, server, nick=None, realname=None, username=None, host=
 
 
 def create_line(buffer, content, kind, user=None):
-    line = IRCLineModel.create(buffer=buffer, content=content, kind=kind, user=user)
+    if user is not None:
+        line = IRCLineModel.create(buffer=buffer, content=content, kind=kind, user=user, nick=user.nick)
+    else:
+        line = IRCLineModel.create(buffer=buffer, content=content, kind=kind, user=user)
     server = line.buffer.server
     signal_factory(new_line).send(None, line=line, server=server)
     return line

--- a/possel/model.py
+++ b/possel/model.py
@@ -294,13 +294,6 @@ class IRCChannel:
         elif msg.startswith('!d raise'):
             raise Error('Debug exception')
 
-    def join(self, password=None):
-        logger.debug('Joining %s', self.name)
-        if password:
-            self._write('JOIN {} {}'.format(self.name, password))
-        else:
-            self._write('JOIN {}'.format(self.name))
-
     def part(self):
         pass
 

--- a/possel/model.py
+++ b/possel/model.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-pircel.model
+possel.model
 ------------
 
 This module defines an API for storing the state of an IRC server and probably includes some database bits too.
@@ -11,10 +11,12 @@ import datetime
 import logging
 
 import peewee as p
-from playhouse import shortcuts
 
 import pircel
 from pircel import protocol, signals
+
+from playhouse import shortcuts
+
 
 logger = logging.getLogger(__name__)
 signal_factory = signals.namespace('model')

--- a/possel/model.py
+++ b/possel/model.py
@@ -8,7 +8,6 @@ This module defines an API for storing the state of an IRC server and probably i
 """
 import collections
 import datetime
-import functools
 import logging
 
 import peewee as p
@@ -19,12 +18,6 @@ from pircel import protocol, signals
 
 logger = logging.getLogger(__name__)
 signal_factory = signals.namespace('model')
-
-
-# Callback signal definitions
-new_line = 'new_line'
-new_buffer = 'new_buffer'
-new_server = 'new_server'
 
 
 class Error(pircel.Error):
@@ -46,7 +39,7 @@ class ModeNotFoundError(Error):
 
 
 class ServerAlreadyAttachedError(Error):
-    """ Exception thrown when someone tries to attach a server handler to a server controller that already has one. """
+    """ Exception thrown when someone tries to attach a server handler to a server interface that already has one. """
 
 
 class KeyDefaultDict(collections.defaultdict):
@@ -184,7 +177,93 @@ def create_tables():
                             ], safe=True)
 
 
-class IRCServerController:
+# Callback signal definitions
+new_user = 'new_user'
+new_line = 'new_line'
+new_buffer = 'new_buffer'
+new_server = 'new_server'
+new_membership = 'new_membership'
+
+
+# =========================================================================
+# Controller functions
+# ------------------
+#
+# Because we really don't need a controller class for this
+# =========================================================================
+def create_user(nick, server, realname=None, username=None, host=None):
+    user = IRCUserModel.create(nick=nick, realname=realname, username=username, host=host, server=server)
+    signal_factory(new_user).send(None, user=user, server=user.server)
+    return user
+
+
+def create_line(buffer, content, kind, user=None):
+    line = IRCLineModel.create(buffer=buffer, content=content, kind=kind, user=user)
+    server = line.buffer.server
+    signal_factory(new_line).send(None, line=line, server=server)
+    return line
+
+
+def create_buffer(name, server):
+    buffer = IRCBufferModel.create(name=name, server=server)
+    signal_factory(new_buffer).send(None, buffer=buffer, server=buffer.server)
+    return buffer
+
+
+def create_membership(buffer, user):
+    membership = IRCBufferMembershipRelation.create(buffer=buffer, user=user)
+    server = membership.buffer.server
+    signal_factory(new_membership).send(None, membership=membership, server=server)
+    return membership
+
+
+def create_server(host, port, secure, nick, realname, username):
+    user = UserDetails.create(nick=nick, realname=realname, username=username)
+    server = IRCServerModel.create(host=host, port=port, secure=secure, user=user)
+    signal_factory(new_server).send(None, server=server)
+    return server
+# =========================================================================
+
+
+# =========================================================================
+# Access functions
+# ----------------
+#
+# Not calling them "view" because they can modify stuff
+# =========================================================================
+def ensure_user(nick, server, realname=None, username=None, host=None):
+    """ Gets a user by (nick, server) and updates the other properties. """
+    try:
+        user = create_user(nick=nick, server=server)
+    except p.IntegrityError:
+        user = IRCUserModel.get(nick=nick, server=server)
+
+    changed = False
+    if realname is not None:
+        user.realname = realname
+        changed = True
+    if username is not None:
+        user.username = username
+        changed = True
+    if host is not None:
+        user.host = host
+        changed = True
+    if changed:
+        user.save()
+
+    return user
+
+
+def ensure_buffer(name, server):
+    try:
+        buffer = create_buffer(name=name, server=server)
+    except p.IntegrityError:
+        buffer = IRCBufferModel.get(name=name, server=server)
+    return buffer
+# =========================================================================
+
+
+class IRCServerInterface:
     def __init__(self, server_model):
         self.server_model = server_model
         self._user = server_model.user
@@ -193,7 +272,6 @@ class IRCServerController:
                                    'join': self._handle_join,
                                    'rpl_namreply': self._handle_rpl_namreply,
                                    }
-        self.callbacks = collections.defaultdict(set)
 
     @property
     def server_handler(self):
@@ -223,36 +301,38 @@ class IRCServerController:
         who = kwargs['prefix']
         channel, = kwargs['args']
         nick, username, host = protocol.parse_identity(who)
+
+        buffer = ensure_buffer(channel, self.server_model)
+
         if nick == self._user.nick:  # *We* are joining a channel
-            buffer, created = IRCBufferModel.get_or_create(name=channel, server=self.server_model)
-            signal_factory(new_buffer).send(self, buffer=buffer.id)
+            pass
         else:  # Someone is joining a channel we're already in
-            buffer = IRCBufferModel.get(name=channel, server=self.server_model)
-            user, created = IRCUserModel.create_or_get(nick=nick,
-                                                       username=username,
-                                                       host=host,
-                                                       server=self.server_model)
-            IRCBufferMembershipRelation.create(buffer=buffer, user=user)
+            user = ensure_user(nick=nick,
+                               username=username,
+                               host=host,
+                               server=self.server_model)
+            create_membership(buffer, user)
 
     def _handle_privmsg(self, _, **kwargs):
         who_from = kwargs['prefix']
         to, msg = kwargs['args']
         nick, username, host = protocol.parse_identity(who_from)
+
         if to == self._user.nick:  # Private Message
-            pass
+            buffer = ensure_buffer(name=nick, server=self.server_model)
         else:  # Hopefully a channel message?
-            buffer = IRCBufferModel.get(name=to)
-            user = IRCUserModel.get(nick=nick)
-            line = IRCLineModel.create(buffer=buffer, user=user, kind='message', content=msg)
-            signal_factory(new_line).send(self, line=line.id)
+            buffer = ensure_buffer(name=to, server=self.server_model)
+
+        user = ensure_user(nick=nick, server=self.server_model)
+        create_line(buffer=buffer, user=user, kind='message', content=msg)
 
     def _handle_rpl_namreply(self, _, **kwargs):
         to, channel_privacy, channel, space_sep_names = kwargs['args']
         names = space_sep_names.split(' ')
-        buffer = IRCBufferModel.get(name=channel)
+        buffer = ensure_buffer(name=channel, server=self.server_model)
         for name in names:
             user = self.get_user_by_nick(name)
-            IRCBufferMembershipRelation.create(user=user, buffer=buffer)
+            create_membership(user=user, buffer=buffer)
     # =========================================================================
 
     # =========================================================================
@@ -273,7 +353,7 @@ class IRCServerController:
         if nick[0] in '@+':
             nick = nick[1:]
 
-        user, created = IRCUserModel.create_or_get(nick=nick, server=self.server_model)
+        user = ensure_user(nick=nick, server=self.server_model)
         return user
 
     @property
@@ -299,7 +379,7 @@ class IRCServerController:
     # =========================================================================
     @classmethod
     def new(cls, host, port, secure, user):
-        server_model = IRCServerModel.create(host=host, port=port, secure=secure, user=user)
+        server_model = create_server(host=host, port=port, secure=secure, user=user)
         return cls(server_model)
 
     @classmethod
@@ -312,281 +392,6 @@ class IRCServerController:
         models = IRCServerModel.select()
         return {model.id: cls(model) for model in models}
     # =========================================================================
-
-
-class ControllerSet:
-    def __init__(self, controllers):
-        self._controllers = {controller.server_model.id for controller in controllers}
-
-    def __getitem__(self, index):
-        return self._controllers[index]
-
-    @property
-    def controllers(self):
-        yield from self._controllers.values()
-
-    def add_callback(self, signal, callback):
-        for controller in self.controllers:
-            controller.add_callback(signal, callback)
-
-    def remove_callback(self, signal, callback):
-        for controller in self.controllers:
-            controller.remove_callback(signal, callback)
-
-
-class _OLD_DEPRECATED_IRCServerController:  # noqa
-    def __init__(self, server_model):
-        pass
-
-    def get_user_full(self, who):
-        """ Return the User object for a given IRC identity string, creating if necessary.
-
-        Args:
-            who (str): Full IRC identity string (as specified in §2.3.1 of rfc2812, second part of "prefix" definition)
-                       of the user
-        Returns:
-            A User object with a nick property that is unique between this method and `get_user_by_nick`; e.g.
-            subsequent calls of either with the same *nick* part will result in the same object being returned.
-        """
-        nick, username, host = protocol.parse_identity(who)
-        try:
-            user = self.users[nick]
-            if not user.fully_known:
-                user.username = username
-                user.fully_known = True
-            return user
-        except KeyError:
-            self.users[nick] = User(nick, username)  # noqa
-            self.users[nick].fully_known = True
-            return self.users[nick]
-
-    def get_user_by_nick(self, nick, channel=None):
-        """ Return the user object from just the nick.
-
-        Will also parse "@nick" or "+nick" properly, and set the mode if the channel is provided.
-
-        Args:
-            nick (str): Either the nick or the nick with a channel mode prefix.
-            channel (str): The name of the channel if this is being called from a 'RPL_NAMREPLY' callback.
-        Returns:
-            A User object for the specified nick; this object will be unique by nick if only this method and
-            `get_user_full` are used to get User objects.
-        """
-        # Pull @ or + off the front
-        # I checked the RFC; these should be the only two chars
-        mode = None
-        if nick[0] in '@+':
-            mode = nick[0]
-            nick = nick[1:]
-
-        # Get or create and get the user object
-        try:
-            user = self.users[nick]
-        except KeyError:
-            self.users[nick] = User(nick)  # noqa
-            user = self.users[nick]
-
-        # Set +o or +v if we need to
-        if channel is not None and mode is not None:
-            mode = {'@': 'o', '+': 'v'}[mode]  # Look it up in a local dict
-            user.modes[channel].add(mode)
-
-        return user
-
-    # ==========
-    # JOIN stuff
-    def on_join(self, who, channel):
-        user = self.get_user_full(who)
-        if user is self.identity:
-            self.self_join(channel)
-        else:
-            self.channels[channel].user_join(user)
-
-    def self_join(self, channel):
-        pass
-
-    def on_rpl_namreply(self, prefix, recipient, secrecy, channel, nicks):
-        """ Sent when you join a channel or run /names """
-        for nick in nicks.split():
-            user = self.get_user_by_nick(nick, channel)
-            self.channels[channel].user_join(user)
-
-    def on_rpl_endofnames(self, *args):
-        """ Sent when we're done with rpl_namreply messages """
-        pass
-    # ==========
-
-    def on_notice(self, prefix, _, message):
-        logger.info('NOTICE: %s', message)
-
-    def on_mode(self, prefix, channel, command, nick):
-        user = self.get_user_by_nick(nick)
-        user.apply_mode_command(channel, command)
-
-    def on_nick(self, who, new_nick):
-        user = self.get_user_full(who)
-        logger.debug('User %s changed nick to %s', user.nick, new_nick)
-        del self.users[user.nick]
-        user.name = new_nick
-        self.users[new_nick] = user
-
-    def on_quit(self, who, message):
-        user = self.get_user_full(who)
-        if user != self.identity:
-            for channel in self.channels:
-                try:
-                    self.channels[channel].user_part(user)
-                except UserNotFoundError:
-                    pass
-
-    def on_part(self, who, channel):
-        user = self.get_user_full(who)
-        if user != self.identity:
-            self.channels[channel].user_part(user)
-
-    def on_privmsg(self, who_from, to, msg):
-        if to.startswith('#'):
-            user = self.get_user_full(who_from)
-            self.channels[to].on_new_message(user, msg)
-
-    def on_rpl_isupport(self, *args):
-        logger.debug('Server supports: %s', args)
-
-    def on_rpl_motdstart(self, *args):
-        self.motd = ''
-
-    def on_rpl_motd(self, prefix, recipient, motd_line):
-        self.motd += motd_line
-        self.motd += '\n'
-
-    def on_rpl_endofmotd(self, *args):
-        logger.info(self.motd)
-        self.who('0')
-
-    def on_rpl_whoreply(self, prefix, recipient, channel, user, host, server, nick, *args):
-        # the last parameter will always be there, there are a bunch of optionals in between
-        *args, hopcount_and_realname = args
-
-        hopcount, realname = hopcount_and_realname.split(' ', maxsplit=1)
-        user = self.get_user_full('{}!{}@{}'.format(nick, user, host))
-        user.real_name = realname
-    # =============
-    # Handlers done
-    # =============
-
-
-@functools.total_ordering
-class _OLD_DEPRECATED_User:  # noqa
-    def __init__(self, name, username=None, real_name=None, password=None):
-        self.name = name
-        self.username = username or name
-        self.real_name = real_name or name
-        self.modes = collections.defaultdict(set)
-        self.fully_known = False
-
-    @property
-    def nick(self):
-        return self.name
-
-    def apply_mode_command(self, channel, command):
-        """ Applies a mode change command.
-
-        Similar syntax to the `chmod` program.
-        """
-        direction, mode = command
-        if direction == '+':
-            self.modes[channel].add(mode)
-        elif direction == '-' and mode in self.modes:
-            self.modes[channel].remove(mode)
-        elif mode not in self.modes:
-            raise ModeNotFoundError(
-                'User "{}" doesn\'t have mode "{}" that we were told to remove'.format(self.name, mode))
-        else:
-            raise protocol.UnknownModeCommandError('Unknown mode change command'
-                                                   ' "{}", expecting "-" or "+"'.format(command))
-
-    def __str__(self):
-        modes = set()
-        for m in self.modes.values():
-            modes |= m
-
-        if self.fully_known:
-            modes.add('&')
-
-        return '{}!{} +{}'.format(self.name, self.username,
-                                  ''.join(modes))
-
-    def __repr__(self):
-        return str(self)
-
-    def __eq__(self, other):
-        return self.name == other.name
-
-    def __lt__(self, other):
-        return self.name < other.name
-
-    def __gt__(self, other):
-        return self.name > other.name
-
-    def __hash__(self):
-        return hash(self.name)
-
-
-class IRCChannel:
-    def __init__(self, name, server, debug_out_loud=False):
-        self.server = server
-        self._write = server.write_function
-        self.name = name
-        self.identity = server.identity
-        self.users = set()
-        self.messages = []
-
-        self._debug_out_loud = debug_out_loud
-
-    def user_join(self, user):
-        logger.debug('%s joined %s', user, self.name)
-        if user.nick in self.users:
-            raise UserAlreadyExistsError(
-                'Tried to add user "{}" to channel {}'.format(user.nick, self.name)
-            )
-        self.users.add(user)
-
-    def user_part(self, user):
-        logger.debug('%s parted from %s', user, self.name)
-        try:
-            self.users.remove(user)
-        except KeyError as e:
-            raise UserNotFoundError(
-                'Tried to remove non-existent nick "{}" from channel {}'.format(user.nick, self.name)) from e
-
-    def on_new_message(self, who_from, msg):
-        self.messages.append((who_from, msg))
-
-        if msg.startswith('!d listmessages'):
-            logger.debug(self.messages)
-
-            if self._debug_out_loud:
-                self.send_message(self.messages)
-
-        elif msg.startswith('!d listusers'):
-            logger.debug(self.server.users)
-
-            if self._debug_out_loud:
-                for user in sorted(self.server.users.values()):
-                    self.send_message(user)
-
-        elif msg.startswith('!d raise'):
-            raise Error('Debug exception')
-
-    def part(self):
-        pass
-
-    def send_message(self, message):
-        if not isinstance(message, (str, bytes)):
-            message = str(message)
-        for line in message.split('\n'):
-            self.messages.append((self.identity, line))
-            self._write('PRIVMSG {} :{}'.format(self.name, line))
 
 
 def main():

--- a/possel/push.py
+++ b/possel/push.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from pircel import model
 from tornado import websocket
 import tornado.web
 
-from possel import auth
+from possel import auth, model
 
 
 logger = logging.getLogger(__name__)

--- a/possel/resources.py
+++ b/possel/resources.py
@@ -11,10 +11,10 @@ resources.
 import json
 import logging
 
-from pircel import model, tornado_adapter
+from pircel import tornado_adapter
 import tornado.web
 
-from possel import auth, commands
+from possel import auth, commands, model
 
 logger = logging.getLogger(__name__)
 insecure_logger = logging.getLogger('insecure.{}'.format(__name__))


### PR DESCRIPTION
Maintaining the git history along the way. And changing the imports so possel uses model from possel.

This is all in aid of having decent auth code, though I could probably figure _something_ out with allowing models to be extended outside of pircel; I kind of feel like the model code is too tightly bound to possel to sensibly be in pircel. e.g. most commits to pircel.model corresponded with commits in possel.
